### PR TITLE
remove enum_default crate from usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cm-telemetry"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Oscar Moreno <oscarmg99@gmail.com>"]
 repository = "https://github.com/ozkar99/cm-telemetry"
 readme = "README.md"
@@ -11,7 +11,6 @@ edition = "2018"
 [dependencies]
 num = "0.4"
 num_enum = "0.5"
-enum_default = "0.2"
 binread = "2.2"
 byteorder = "1"
 bitflags = "1.3.2"

--- a/src/f1/f1_2020.rs
+++ b/src/f1/f1_2020.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 
 use binread::{BinRead, BinReaderExt};
-use enum_default::EnumDefault;
 use num_enum::TryFromPrimitive;
 
 /// F1_2020 implements the codemasters UDP telemetry protocol for "F1 2020"
@@ -112,7 +111,7 @@ impl Session {
     }
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Weather {
     Clear,
@@ -121,14 +120,16 @@ pub enum Weather {
     LightRain,
     HeavyRain,
     Storm,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(Weather, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(i8)]
 pub enum Track {
+    #[default]
     Unknown = -1,
     Melbourne,
     PaulRicard,
@@ -161,24 +162,26 @@ pub enum Track {
 
 binread_enum!(Track, i8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Formula {
     F1Modern,
     F1Classic,
     F2,
     F1Generic,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(Formula, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum SafetyCarStatus {
     NoSafetyCar,
     FullSafetyCar,
     VirtualSafetyCar,
+    #[default]
     Unknown = 255,
 }
 
@@ -190,9 +193,10 @@ pub struct MarshalZone {
     pub zone_flag: ZoneFlag,
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(i8)]
 pub enum ZoneFlag {
+    #[default]
     Unknown = -1,
     None,
     Green,
@@ -212,9 +216,10 @@ pub struct WeatherForecastSample {
     pub air_temperature: i8,
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum SessionType {
+    #[default]
     Unknown,
     Practice1,
     Practice2,
@@ -282,29 +287,31 @@ pub struct BestOverallSectorTime {
     pub lap_number: u8,
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum PitStatus {
     None,
     Pitting,
     InPitArea,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(PitStatus, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Sector {
     Sector1,
     Sector2,
     Sector3,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(Sector, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum DriverStatus {
     InGarage,
@@ -312,12 +319,13 @@ pub enum DriverStatus {
     InLap,
     OutLap,
     InTrack,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(DriverStatus, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum ResultStatus {
     Invalid,
@@ -328,6 +336,7 @@ pub enum ResultStatus {
     NotClassified,
     Retired,
     MechanicalFailure,
+    #[default]
     Unknown = 255,
 }
 
@@ -423,7 +432,7 @@ pub struct PenaltyEventDetail {
     pub places_gained: u8,
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum PenaltyType {
     DriveThrough,
@@ -444,12 +453,13 @@ pub enum PenaltyType {
     ThisAndPreviousLapInvalidatedWithNoReason,
     Retired,
     BlackFlagTimer,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(PenaltyType, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum InfringementType {
     BlockingBySlowDriving,
@@ -504,6 +514,7 @@ pub enum InfringementType {
     RetryPenalty,
     IllegalTimeGain,
     MandatoryPitstop,
+    #[default]
     Unknown = 255,
 }
 
@@ -548,7 +559,7 @@ fn participant_name_parser<R: binread::io::Read + binread::io::Seek>(
     Ok(String::from(driver_name))
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Driver {
     CarlosSainz,
@@ -631,12 +642,13 @@ pub enum Driver {
     GuilianoAlesi,
     RalphBoschung,
     MyDriver = 100,
+    #[default]
     Unknown = 255, // Used for time trial "ghost" drivers that appear randomly
 }
 
 binread_enum!(Driver, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Team {
     Mercedes,
@@ -698,15 +710,17 @@ pub enum Team {
     Ferrari1990 = 63,
     McLaren2010,
     Ferrari2010,
+    #[default]
     Unknown = 254,
     MyTeam = 255,
 }
 
 binread_enum!(Team, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Nationality {
+    #[default]
     Unknown,
     American,
     Argentinean,
@@ -878,7 +892,7 @@ fn surface_type_parser<R: binread::io::Read + binread::io::Seek>(
     })
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(i8)]
 pub enum Gear {
     Reverse = -1,
@@ -891,12 +905,13 @@ pub enum Gear {
     Sixth,
     Seventh,
     Eigth,
+    #[default]
     Unknown = 127,
 }
 
 binread_enum!(Gear, i8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Surface {
     Tarmac,
@@ -911,12 +926,13 @@ pub enum Surface {
     Cobblestone,
     Metal,
     Ridged,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(Surface, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum MFDPanel {
     CarSetup,
@@ -924,6 +940,7 @@ pub enum MFDPanel {
     Damage,
     Engine,
     Temperatures,
+    #[default]
     Unknown,
     Closed = 255,
 }
@@ -971,36 +988,39 @@ pub struct CarStatusData {
     pub ers_data: ERS,
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum FuelMix {
     Lean,
     Standard,
     Rich,
     Max,
+    #[default]
     Unknown,
 }
 
 binread_enum!(FuelMix, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum DRSAllowed {
     NotAllowed,
     Allowed,
+    #[default]
     Unknown,
 }
 
 binread_enum!(DRSAllowed, u8);
 
-#[derive(Debug, EnumDefault)]
+#[derive(Debug, Default)]
 #[repr(u16)]
 pub enum DRSActivationDistance {
+    #[default]
     NotAvailable,
     Distance(u16),
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum TyreCompound {
     Inter = 7,
@@ -1017,12 +1037,13 @@ pub enum TyreCompound {
     C3,
     C2,
     C1,
+    #[default]
     Unknown,
 }
 
 binread_enum!(TyreCompound, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum TyreVisual {
     Inter = 7,
@@ -1030,14 +1051,16 @@ pub enum TyreVisual {
     Soft = 16,
     Medium = 17,
     Hard = 18,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(TyreVisual, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(i8)]
 pub enum FiaFlag {
+    #[default]
     Unknown = -1,
     None,
     Green,
@@ -1057,13 +1080,14 @@ pub struct ERS {
     pub deployed_this_lap: f32,
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum ERSDeployMode {
     None,
     Medium,
     Overtake,
     Hotlap,
+    #[default]
     Unknown = 255,
 }
 
@@ -1133,12 +1157,13 @@ pub struct LobbyInfoData {
     pub status: LobbyStatus,
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum LobbyStatus {
     NotReady,
     Ready,
     Spectating,
+    #[default]
     Unknown,
 }
 

--- a/src/f1/f1_2022.rs
+++ b/src/f1/f1_2022.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 
 use binread::{BinRead, BinReaderExt};
-use enum_default::EnumDefault;
 use num_enum::TryFromPrimitive;
 use bitflags::bitflags;
 
@@ -149,9 +148,10 @@ pub struct Session {
                                                                 // 5 = Medium Long, 6 = Long, 7 = Full
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Weather {
+    #[default]
     Clear,
     LigthCloud,
     Overcast,
@@ -163,9 +163,10 @@ pub enum Weather {
 
 binread_enum!(Weather, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum SessionType {
+    #[default]
     Unknown,
     Practice1,
     Practice2,
@@ -185,9 +186,10 @@ pub enum SessionType {
 binread_enum!(SessionType, u8);
 
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(i8)]
 pub enum Track {
+    #[default]
     Unknown = -1,
     Melbourne,
     PaulRicard,
@@ -224,9 +226,10 @@ pub enum Track {
 
 binread_enum!(Track, i8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Formula {
+    #[default]
     F1Modern,
     F1Classic,
     F2,
@@ -246,9 +249,10 @@ pub struct MarshalZone {
     pub zone_flag: ZoneFlag,    // -1 = invalid/unknown, 0 = none, 1 = green, 2 = blue, 3 = yellow, 4 = red
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(i8)]
 pub enum ZoneFlag {
+    #[default]
     Unknown = -1,
     None,
     Green,
@@ -259,9 +263,10 @@ pub enum ZoneFlag {
 
 binread_enum!(ZoneFlag, i8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum SafetyCarStatus {
+    #[default]
     NoSafetyCar,
     FullSafetyCar,
     VirtualSafetyCar,
@@ -286,9 +291,10 @@ pub struct WeatherForecastSample {
     pub rain_percentage: u8,                                // Rain percentage (0-100)
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(i8)]
 pub enum WeatherTemperatureTrend {
+    #[default]
     Unknown = -1,
     Up,
     Down,
@@ -297,9 +303,10 @@ pub enum WeatherTemperatureTrend {
 
 binread_enum!(WeatherTemperatureTrend, i8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum ForecastAccuracy {
+    #[default]
     Perfect,
     Approximate,
     Unknown = 255,
@@ -307,9 +314,10 @@ pub enum ForecastAccuracy {
 
 binread_enum!(ForecastAccuracy, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum BrakingAssist {
+    #[default]
     Off,
     Low,
     Medium,
@@ -319,9 +327,10 @@ pub enum BrakingAssist {
 
 binread_enum!(BrakingAssist, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum GearboxAssist {
+    #[default]
     Manual = 1,
     ManualAndSuggest,
     Auto,
@@ -330,9 +339,10 @@ pub enum GearboxAssist {
 
 binread_enum!(GearboxAssist, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum RacingLine {
+    #[default]
     Off,
     CornersOnly,
     Full,
@@ -341,9 +351,10 @@ pub enum RacingLine {
 
 binread_enum!(RacingLine, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum RacingLineType {
+    #[default]
     TwoD,
     ThreeD,
     Unknown = 255,
@@ -351,9 +362,10 @@ pub enum RacingLineType {
 
 binread_enum!(RacingLineType, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum GameMode {
+    #[default]
     EventMode,
     GrandPrix = 3,
     TimeTrial = 5,
@@ -373,9 +385,10 @@ pub enum GameMode {
 
 binread_enum!(GameMode, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum RuleSet {
+    #[default]
     PracticeAndQualifying,
     Race,
     TimeTrial,
@@ -390,9 +403,10 @@ pub enum RuleSet {
 
 binread_enum!(RuleSet, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum SessionLength {
+    #[default]
     None,
     VeryShort = 2,
     Short,
@@ -453,9 +467,10 @@ pub struct Lap {
 	           
 
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum PitStatus {
+    #[default]
     None,
     Pitting,
     InPitArea,
@@ -464,18 +479,19 @@ pub enum PitStatus {
 
 binread_enum!(PitStatus, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Sector {
     Sector1,
     Sector2,
     Sector3,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(Sector, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum DriverStatus {
     InGarage,
@@ -483,12 +499,13 @@ pub enum DriverStatus {
     InLap,
     OutLap,
     OnTrack,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(DriverStatus, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum ResultStatus {
     Invalid,
@@ -499,6 +516,7 @@ pub enum ResultStatus {
     Disqualified,
     NotClassified,
     Retired,
+    #[default]
     Unknown = 255,
 }
 
@@ -671,7 +689,7 @@ pub struct PenaltyEventDetail {
     pub places_gained: u8,                  // Number of places gained by this
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum PenaltyType {
     DriveThrough,
@@ -692,12 +710,13 @@ pub enum PenaltyType {
     ThisAndPreviousLapInvalidatedWithNoReason,
     Retired,
     BlackFlagTimer,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(PenaltyType, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum InfringementType {
     BlockingBySlowDriving,
@@ -755,6 +774,7 @@ pub enum InfringementType {
     IllegalTimeGain,
     MandatoryPitstop,
     AttributeAssigned,
+    #[default]
     Unknown = 255,
 }
 
@@ -820,7 +840,7 @@ fn participant_name_parser<R: binread::io::Read + binread::io::Seek>(
 }
 
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Driver {
     CarlosSainz,
@@ -949,13 +969,14 @@ pub enum Driver {
     AmauryCordeel,
     MikaHakkinen,
 
+    #[default]
     Unknown,
     Human = 255, // Used for time trial "ghost" drivers that appear randomly
 }
 
 binread_enum!(Driver, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Team {
     Mercedes,
@@ -1011,14 +1032,16 @@ pub enum Team {
     Campos2022,
     VanAmersfoortRacing2022,
     Trident2022,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(Team, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Nationality {
+    #[default]
     Unknown,
     American,
     Argentinean,
@@ -1179,7 +1202,7 @@ pub struct CarTelemetryData {
     pub surface_type: WheelValue<Surface>,          // Driving surface, see appendices
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(i8)]
 pub enum Gear {
     Reverse = -1,
@@ -1192,12 +1215,13 @@ pub enum Gear {
     Sixth,
     Seventh,
     Eigth,
+    #[default]
     Unknown = 127,
 }
 
 binread_enum!(Gear, i8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Surface {
     Tarmac,
@@ -1212,6 +1236,7 @@ pub enum Surface {
     Cobblestone,
     Metal,
     Ridged,
+    #[default]
     Unknown = 255,
 }
 
@@ -1233,7 +1258,7 @@ fn surface_type_parser<R: binread::io::Read + binread::io::Seek>(
     })
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum MFDPanel {
     CarSetup,
@@ -1241,6 +1266,7 @@ pub enum MFDPanel {
     Damage,
     Engine,
     Temperatures,
+    #[default]
     Unknown = 128,
     Closed = 255,
 }
@@ -1296,26 +1322,28 @@ pub struct CarStatusData {
     pub network_paused: u8,                                     // Whether the car is paused in a network game
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum FuelMix {
     Lean,
     Standard,
     Rich,
     Max,
+    #[default]
     Unknown,
 }
 
 binread_enum!(FuelMix, u8);
 
-#[derive(Debug, EnumDefault)]
+#[derive(Debug, Default)]
 #[repr(u16)]
 pub enum DRSActivationDistance {
+    #[default]
     NotAvailable,
     Distance(u16),
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum TyreCompound {
     Inter = 7,
@@ -1332,12 +1360,13 @@ pub enum TyreCompound {
     C3,
     C2,
     C1,
+    #[default]
     Unknown,
 }
 
 binread_enum!(TyreCompound, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum TyreVisual {
     Inter = 7,
@@ -1352,14 +1381,16 @@ pub enum TyreVisual {
     F2Soft,
     F2Medium,
     F2Hard,
+    #[default]
     Unknown = 255,
 }
 
 binread_enum!(TyreVisual, u8);
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(i8)]
 pub enum FiaFlag {
+    #[default]
     Unknown = -1,
     None,
     Green,
@@ -1380,13 +1411,14 @@ pub struct ERS {
     pub deployed_this_lap: f32,         // ERS energy deployed this lap
 }
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum ERSDeployMode {
     None,
     Medium,
     Hotlap,
     Overtake,
+    #[default]
     Unknown = 255,
 }
 
@@ -1460,12 +1492,13 @@ pub struct LobbyInfoData {
     pub status: LobbyStatus,                    // 0 = not ready, 1 = ready, 2 = spectating
 }      
 
-#[derive(Debug, TryFromPrimitive, EnumDefault)]
+#[derive(Debug, Default, TryFromPrimitive)]
 #[repr(u8)]
 pub enum LobbyStatus {
     NotReady,
     Ready,
     Spectating,
+    #[default]
     Unknown,
 }
 

--- a/src/f1/macros.rs
+++ b/src/f1/macros.rs
@@ -15,7 +15,7 @@ pub(crate) use player_data;
 
 /// binread_enum implements a default BinRead trait for enums
 /// arguments are the enum to implement and the size of it
-/// note: enum has to have an "Unknown" element and implement TryFromPrimitive trait
+/// note: enum has to implement "Default" and "TryFromPrimitive" traits.
 macro_rules! binread_enum {
     ($type:ident, $repr:ident) => {
         impl binread::BinRead for $type {
@@ -26,7 +26,7 @@ macro_rules! binread_enum {
                 args: Self::Args,
             ) -> binread::BinResult<Self> {
                 let byte = $repr::read_options(reader, options, args)?;
-                Ok($type::try_from(byte).unwrap_or($type::Unknown))
+                Ok($type::try_from(byte).unwrap_or($type::default()))
             }
         }
     };


### PR DESCRIPTION
removed enum_default as rust implements Default for enums as a language construct via: https://rust-lang.github.io/rfcs/3107-derive-default-enum.html