### PR TITLE
Session Type fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,6 @@ PR's welcome :)
 
 ### Furter Reading
 
-https://forums.codemasters.com/topic/50942-f1-2020-udp-specification/
-https://answers.ea.com/t5/General-Discussion/F1-22-UDP-Specification/td-p/11551274
+[F1 2020 UDP Specification](https://web.archive.org/web/20221127112921/https://forums.codemasters.com/topic/50942-f1-2020-udp-specification/)       (Webarchive because EA)
+
+[F1 2022 UDP Specification](https://answers.ea.com/t5/General-Discussion/F1-22-UDP-Specification/td-p/11551274)

--- a/src/f1/f1_2020.rs
+++ b/src/f1/f1_2020.rs
@@ -231,7 +231,7 @@ pub enum SessionType {
     ShortQualifier,
     OSQ,
     Race,
-    Formula2Race,
+    R2,
     TimeTrial,
 }
 

--- a/src/f1/f1_2022.rs
+++ b/src/f1/f1_2022.rs
@@ -178,7 +178,7 @@ pub enum SessionType {
     ShortQualifier,
     OSQ,
     Race,
-    Formula2Race,
+    R2,
     R3,
     TimeTrial,
 }


### PR DESCRIPTION
The F1 Telemetry specifiactions does not have an entry for *Formula2Race* in SessionType. They call it *R2*.
After testing with sprint races in F1 22 this seems to be right.
The first Race, in this case the spring will be *Race* and the second race, the main race, will then be *R2*.

I updated the F1 22 code as well as the F1 20 code to resemble this.
I assume it will be the same for the older one, especially when considering Formula2 Races, which have two races per weekend. (But i did not test it for this case)

Also added the Webarchive link for the F1 20 specification, because EA has removed the codemasters forum